### PR TITLE
[FEAT] 태그 색상 매핑 테이블 추가

### DIFF
--- a/src/constants/tagColorMap.js
+++ b/src/constants/tagColorMap.js
@@ -17,3 +17,10 @@ export const TAG_COLOR_MAP = {
 };
 
 export const getTagColor = (index) => TAG_COLOR_MAP[index] || "#000000";
+
+export const getColorIndex = (hex) => {
+  const entry = Object.entries(TAG_COLOR_MAP).find(
+    ([, value]) => value.toLowerCase() === hex.toLowerCase()
+  );
+  return entry ? Number(entry[0]) : null;
+};

--- a/src/constants/tagColorMap.js
+++ b/src/constants/tagColorMap.js
@@ -1,0 +1,19 @@
+export const TAG_COLOR_MAP = {
+  0: "#2BE99A",
+  1: "#50B0FF",
+  2: "#525252",
+  3: "#986DFF",
+  4: "#A0D4FF",
+  5: "#A6FBD7",
+  6: "#AEAEAE",
+  7: "#D9C9FF",
+  8: "#E8E8E8",
+  9: "#F6553C",
+  10: "#FE72C1",
+  11: "#FFA091",
+  12: "#FFC9E8",
+  13: "#FFD258",
+  14: "#FFEBB5",
+};
+
+export const getTagColor = (index) => TAG_COLOR_MAP[index] || "#000000";

--- a/src/pages/mainPage/components/MainCalendar.jsx
+++ b/src/pages/mainPage/components/MainCalendar.jsx
@@ -3,7 +3,7 @@ import "react-calendar/dist/Calendar.css";
 import * as S from "../styles/MainCalendar.style";
 import { vw } from "@/utils/units";
 import PlanTag from "./PlanTag";
-import { getTagColor as getColorFromMap } from "@/constants/tagColors";
+import { getTagColor as getColorFromMap } from "../../../constants/tagColorMap";
 
 const MainCalendar = ({
   tags,

--- a/src/pages/mainPage/components/MainCalendar.jsx
+++ b/src/pages/mainPage/components/MainCalendar.jsx
@@ -3,6 +3,7 @@ import "react-calendar/dist/Calendar.css";
 import * as S from "../styles/MainCalendar.style";
 import { vw } from "@/utils/units";
 import PlanTag from "./PlanTag";
+import { getTagColor as getColorFromMap } from "@/constants/tagColors";
 
 const MainCalendar = ({
   tags,
@@ -15,7 +16,7 @@ const MainCalendar = ({
     if (!tag) return "#EAEAEA";
     if (typeof tag === "object" && tag.color) return tag.color;
     const match = tags.find((t) => t.name === tag);
-    return match ? match.color : "#EAEAEA";
+    return match ? match.color : getColorFromMap(tag.colorIndex ?? 0);
   };
 
   const visibleSchedules = Array.isArray(schedules)

--- a/src/pages/mainPage/components/MainLeftSection.jsx
+++ b/src/pages/mainPage/components/MainLeftSection.jsx
@@ -30,6 +30,7 @@ const MainLeftSection = ({
   setSelectedTag,
   selectedTag,
   onRenameTag,
+  isGoogleSynced,
 }) => {
   const [isSettingActive, setIsSettingActive] = useState(false);
   const [isEditActive, setIsEditActive] = useState(null);
@@ -78,6 +79,11 @@ const MainLeftSection = ({
   };
 
   const handleColorChange = async (tag, newHex) => {
+    if (isGoogleSynced) {
+      console.log("Google 연동 중에는 색상 변경이 비활성화됩니다.");
+      return;
+    }
+
     const colorIndex = getColorIndex(newHex);
     if (colorIndex === null) return;
 
@@ -164,7 +170,7 @@ const MainLeftSection = ({
                     onClick={() => handleCheckClick(tag)}
                   />
 
-                  {activeColorTag === tag.id && (
+                  {activeColorTag === tag.id && !isGoogleSynced && (
                     <S.ColorChipWrapper>
                       <ColorChip
                         onSelect={(color) => handleColorChange(tag, color)}

--- a/src/pages/mainPage/components/MainLeftSection.jsx
+++ b/src/pages/mainPage/components/MainLeftSection.jsx
@@ -12,6 +12,8 @@ import { useEffect, useState } from "react";
 import ColorChip from "../../../components/colorchip/ColorChip";
 import tagEditApi from "../../../apis/tag/tagEditApi";
 
+import { TAG_COLOR_MAP, getColorIndex } from "../../../constants/tagColorMap";
+
 const days = [
   "일요일",
   "월요일",
@@ -72,6 +74,22 @@ const MainLeftSection = ({
       console.log("태그 수정 성공: ", res.detail);
     } catch (error) {
       console.error("태그 수정 실패: ", error);
+    }
+  };
+
+  const handleColorChange = async (tag, newHex) => {
+    const colorIndex = getColorIndex(newHex);
+    if (colorIndex === null) return;
+
+    setTags((prev) =>
+      prev.map((t) => (t.id === tag.id ? { ...t, color: colorIndex } : t))
+    );
+
+    try {
+      await tagEditApi(tag.id, tag.name, colorIndex, tag.calendar);
+      console.log("색상 변경 성공");
+    } catch (err) {
+      console.error("색상 변경 실패: ", err);
     }
   };
 
@@ -138,19 +156,18 @@ const MainLeftSection = ({
                     $isSelected={
                       selectedTagId === null || selectedTagId === tag.id
                     }
-                    $color={tag.color}
+                    $color={
+                      typeof tag.color === "number"
+                        ? TAG_COLOR_MAP[tag.color] // 사용자 태그
+                        : tag.color || "#EAEAEA" // 디폴트 태그
+                    }
                     onClick={() => handleCheckClick(tag)}
                   />
+
                   {activeColorTag === tag.id && (
                     <S.ColorChipWrapper>
                       <ColorChip
-                        onSelect={(color) => {
-                          setTags((prev) =>
-                            prev.map((t) =>
-                              t.id === tag.id ? { ...t, color } : t
-                            )
-                          );
-                        }}
+                        onSelect={(color) => handleColorChange(tag, color)}
                       />
                     </S.ColorChipWrapper>
                   )}

--- a/src/pages/mainPage/components/MainLeftSection.jsx
+++ b/src/pages/mainPage/components/MainLeftSection.jsx
@@ -10,7 +10,6 @@ import EDITING from "@/assets/main/tagediting.svg";
 
 import { useEffect, useState } from "react";
 import ColorChip from "../../../components/colorchip/ColorChip";
-import tagGetApi from "@/apis/tag/tagGetApi";
 import tagEditApi from "../../../apis/tag/tagEditApi";
 
 const days = [
@@ -36,7 +35,9 @@ const MainLeftSection = ({
 
   const [selectedTagId, setSelectedTagId] = useState(null);
   const [editedTags, setEditedTags] = useState({});
-  
+
+  const USER_ID = sessionStorage.getItem("user_id");
+
   const today = new Date();
 
   const year = today.getFullYear();
@@ -67,7 +68,7 @@ const MainLeftSection = ({
 
     try {
       const tag = tags.find((t) => t.id === id);
-      const res = await tagEditApi(id, newName, tag.color, 13);
+      const res = await tagEditApi(id, newName, tag.color, USER_ID);
       console.log("태그 수정 성공: ", res.detail);
     } catch (error) {
       console.error("태그 수정 실패: ", error);
@@ -166,7 +167,6 @@ const MainLeftSection = ({
                     />
                   ) : (
                     <S.TodoText>{editedTags[tag.id] || tag.name}</S.TodoText>
-
                   )}
                 </S.TodoContainer>
                 {isSettingActive && (

--- a/src/pages/mainPage/components/MainRightSection.jsx
+++ b/src/pages/mainPage/components/MainRightSection.jsx
@@ -4,6 +4,8 @@ import GOOGLE from "@/assets/main/google.svg";
 import ANDY from "@/assets/main/andy.svg";
 import PlanTag from "./PlanTag";
 
+import { TAG_COLOR_MAP } from "../../../constants/tagColorMap";
+
 const MainRightSection = ({
   tags,
   schedules = [],
@@ -26,7 +28,14 @@ const MainRightSection = ({
 
   const getTagColor = (tagName) => {
     const match = tags.find((t) => t.name === tagName);
-    return match ? match.color : "#EAEAEA";
+
+    if (!match) return "#EAEAEA";
+
+    if (typeof match.color === "number") {
+      return TAG_COLOR_MAP[match.color] || "#EAEAEA";
+    }
+
+    return match.color || "#EAEAEA";
   };
 
   const filteredSchedules = selectedTag


### PR DESCRIPTION
## Related issue 🛠
- closed #63 

## Work Description 📝
- tagColorMap.js 파일 생성 후 전체 태그 색상 반영되도록 설정

## To Reviewers 📢
등록 모달 (RegisterModal.jsx) 부분에서 

import { getColorIndex } from "@/constants/tagColorMap";

const tagPayload = { name: pickedTag.name, color: 0 }; 여기 임시로 0 보내는 부분을 
color: getColorIndex(pickedTag.color) ?? 0, 로 수정하여 기본 태그 및 새로 만든 태그 전부 인덱스 변환 후 매핑되도록 사용

이렇게 색상 매핑 함수 임포트하고 이벤트 생성 API 호출 직전 부분을 수정해 주시면 될 것 같아요
(민지님이 작성하신 코드를 제가 잘못 이해했을 수도 있어서... 해 보고 안 되면 말씀해 주세용)

그리고 태그 선택하는 부분에선 디폴트 태그 목록 표시 외에 새로운 태그 설정 시 
색상 지정 부분은 공통 컴포넌트 ColorChip.jsx 연결해서 사용하시면 됩니다!