### PR TITLE
feat: 일정 등록하기 태그 색상 API  반영

### DIFF
--- a/src/components/modals/register/RegisterModal.jsx
+++ b/src/components/modals/register/RegisterModal.jsx
@@ -11,6 +11,8 @@ import ALLDAY_ICON from "@/assets/modal/allday.svg";
 import { createEventApi } from "@/apis/calendar/createEventApi";
 import { taskProcessApi } from "@/apis/analysis/taskProcessApi";
 import { taskGetApi } from "@/apis/analysis/taskGetApi";
+import { getColorIndex } from "@/constants/tagColorMap";
+import ColorChip from "@/components/colorchip/ColorChip";
 
 function RegisterModal({
   open,
@@ -38,19 +40,14 @@ function RegisterModal({
   const [tagOpen, setTagOpen] = useState(false);
   const [selectedTagId, setSelectedTagId] = useState("");
   const [tagList, setTagList] = useState([
-    { id: "t1", name: "개인 일정", color: "#FFE28C" },
-    { id: "t2", name: "개인 일정", color: "#E0C3FF" },
-    { id: "t3", name: "개인 일정", color: "#A6D8FF" },
-    { id: "t4", name: "운동하기", color: "#C8E9FF" },
+    { id: "t1", name: "학업", color: "#FFD258" },
+    { id: "t2", name: "일상", color: "#D9C9FF" },
+    { id: "t3", name: "건강", color: "#A0D4FF" },
   ]);
   const tagListRef = useRef(tagList);
-  const COLOR_OPTIONS = [
-    "#5E81F4","#7E8DF5","#A6D8FF","#C8E9FF","#FFE28C","#FFD966","#FFAFCC","#E0C3FF",
-    "#B3F5D0","#9AE6B4","#FFD1DC","#FFDEA0","#90CDF4","#63B3ED","#CBD5E0","#A0AEC0"
-  ];
   const MAX_TAGS = 5;
   const [newTagName, setNewTagName] = useState("");
-  const [newTagColor, setNewTagColor] = useState("#E3E8FF");
+  const [newTagColor, setNewTagColor] = useState("#2BE99A");
   const [addingNewTag, setAddingNewTag] = useState(false);
   const [manualConfirmed, setManualConfirmed] = useState(false);
   const [mode, setMode] = useState("create"); // create | edit
@@ -314,8 +311,10 @@ function RegisterModal({
         const pickedTag =
           tagListRef.current.find((t) => t.id === form.tagId) ||
           tagListRef.current[0] || { name: "기본", color: "#B4BFFF" };
-        // 서버 스펙상 color는 number인 경우가 있어 임시 0으로 보냄(서버에서 매핑)
-        const tagPayload = { name: pickedTag.name, color: 0 };
+        const tagPayload = {
+          name: pickedTag.name,
+          color: getColorIndex(pickedTag.color) ?? 0,
+        };
 
         const payload = {
           title: form.title || "제목 없음",
@@ -350,6 +349,7 @@ function RegisterModal({
             startDate: (startISO || "").slice(0,10),
             endDate: (endISO || "").slice(0,10),
             tag: tagName,
+            tagColorIndex: tagPayload.color,
             title: payload.title,
             repeat: payload.repeat,
             until: (payload.until || "")?.slice?.(0,10) || null,
@@ -379,6 +379,7 @@ function RegisterModal({
               startDate: form.startDate,
               endDate: form.endDate || form.startDate,
               tag: pickedTag.name,
+              tagColorIndex: getColorIndex(pickedTag.color) ?? 0,
               title: form.title || "제목 없음",
               repeat: form.repeatOn ? (form.repeatType === "weekly" ? "WEEKLY" : "DAILY") : "NONE",
               until: form.repeatOn && form.repeatEnd ? form.repeatEnd : null,
@@ -862,17 +863,11 @@ function RegisterModal({
                             {addingNewTag && (
                               <>
                                 <S.Palette>
-                                  {COLOR_OPTIONS.map((c) => (
-                                    <S.ColorDot
-                                      key={c}
-                                      $color={c}
-                                      $active={newTagColor === c}
-                                      onClick={(e) => {
-                                      e.stopPropagation();
-                                        setNewTagColor(c);
-                                      }}
-                                    />
-                                  ))}
+                                  <ColorChip
+                                    onSelect={(c) => {
+                                      setNewTagColor(c);
+                                    }}
+                                  />
                                 </S.Palette>
                                 <S.TagNameRow>
                                   <S.SmallInput style={{ width: "100%" }}>

--- a/src/pages/mainPage/MainPage.jsx
+++ b/src/pages/mainPage/MainPage.jsx
@@ -10,6 +10,7 @@ import GoogleModal from "../loginPage/components/GoogleModal";
 import googleSyncApi from "../../apis/auth/googleSyncApi";
 import tagGetApi from "../../apis/tag/tagGetApi";
 import allPlanGetApi from "../../apis/main/allPlanGetApi";
+import { TAG_COLOR_MAP } from "../../constants/tagColorMap";
 
 const MainPage = () => {
   const location = useLocation();
@@ -150,7 +151,15 @@ const MainPage = () => {
           if (newItem?.tag && !tags.some((t) => t.name === newItem.tag)) {
             setTags((prev) => [
               ...prev,
-              { id: Date.now(), name: newItem.tag, color: "#A0D4FF" },
+              {
+                id: Date.now(),
+                name: newItem.tag,
+                // 서버 스펙에 맞춰 사용자 태그는 color 인덱스(숫자)로 유지
+                color:
+                  typeof newItem.tagColorIndex === "number"
+                    ? newItem.tagColorIndex
+                    : 3, // 기본 인덱스(보라) fallback
+              },
             ]);
           }
           // 날짜/반복 규칙에 따라 범위 확장


### PR DESCRIPTION
## Related issue 🛠
- closed #69 

## Work Description 📝

- 일정 등록하기 태그 색상 API  반영
- 메인에도 반영

## Screenshot 📸
<img width="1204" height="505" alt="KakaoTalk_Photo_2025-11-12-20-18-38" src="https://github.com/user-attachments/assets/6568ec7d-e928-4d2a-a621-ea30894caa18" />
<img width="434" height="390" alt="KakaoTalk_Photo_2025-11-12-20-18-41" src="https://github.com/user-attachments/assets/dbafeb0b-ed6e-40eb-83d1-909f60945259" />
<img width="1774" height="1009" alt="KakaoTalk_Photo_2025-11-12-20-18-33" src="https://github.com/user-attachments/assets/479bbd39-326c-4158-9c29-48c7c01a8b89" />


## To Reviewers 📢
