### PR TITLE
feat: 이미지 분석 일정 수정하기 API 연동

### DIFF
--- a/src/apis/calendar/updateEventApi.js
+++ b/src/apis/calendar/updateEventApi.js
@@ -1,0 +1,13 @@
+import instance from "@/apis/utils/instance";
+
+// 개별 일정 수정
+// PATCH /calendar/events/{id}
+// body는 수정할 항목만 전송
+export async function updateEventApi(eventId, body) {
+  if (!eventId) throw new Error("eventId is required");
+  const url = `/calendar/events/${eventId}`;
+  const { data } = await instance.patch(url, body);
+  return data;
+}
+
+


### PR DESCRIPTION
## Related issue 🛠

- closed #72

## Work Description 📝

- 이미지 분석 일정 수정하기 API 연동
- 취소하기 눌렀으면 그냥 엑스 버튼 한 것과 동일 효과
- 이미지 분석 일정에서 등록하기 버튼 누르면 수정 없이 바로 일정 등록
- 수정하기 버튼 누르면 수정 가능하고 저장하기 누르면 해당 일정 캘린더 표시

## Screenshot 📸
<img width="787" height="488" alt="스크린샷 2025-11-13 오전 1 35 22" src="https://github.com/user-attachments/assets/3de4ca0a-ec6f-4d71-9d3c-7d065b55d047" />
<img width="893" height="747" alt="스크린샷 2025-11-13 오전 1 35 46" src="https://github.com/user-attachments/assets/51f831dc-d92f-40dc-aafc-0379c5502346" />

<img src="" width="1920"/>

## To Reviewers 📢
